### PR TITLE
Add right-click copy json file feature

### DIFF
--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -44,6 +44,10 @@ const electronAPI = {
   renameFile: (oldPath: string, newPath: string): Promise<{ success: boolean; filePath?: string; error?: string }> =>
     ipcRenderer.invoke('rename-file', oldPath, newPath),
 
+  // 复制文件
+  copyFile: (filePath: string, newPath: string): Promise<{ success: boolean; filePath?: string; error?: string }> =>
+    ipcRenderer.invoke('copy-file', filePath, newPath),
+
   // Schema JSON file operations
   createSchemaJsonDirectory: (schemaName: string): Promise<{ success: boolean; path?: string; error?: string }> =>
     ipcRenderer.invoke('create-schema-json-directory', schemaName),

--- a/src/components/ContextMenu.vue
+++ b/src/components/ContextMenu.vue
@@ -15,6 +15,8 @@
     
     <!-- File context menu items -->
     <template v-if="contextType === 'file'">
+      <div class="context-menu-item" @click="handleCopyFile">Copy File</div>
+      <div class="context-menu-separator"></div>
       <div class="context-menu-item" @click="handleViewFile">View File</div>
       <div class="context-menu-item" @click="handleEditFile">Edit File</div>
       <div class="context-menu-separator"></div>

--- a/src/services/fileService.ts
+++ b/src/services/fileService.ts
@@ -107,5 +107,18 @@ export class FileService {
     // Web mode fallback: pretend success
     return { success: true, filePath: newPath }
   }
+
+  async copyFile(filePath: string, newPath: string): Promise<WriteResult> {
+    if (window.electronAPI?.copyFile) {
+      try {
+        const result = await window.electronAPI.copyFile(filePath, newPath)
+        return result
+      } catch (error: any) {
+        return { success: false, error: String(error) }
+      }
+    }
+    // Web mode fallback: pretend success
+    return { success: true, filePath: newPath }
+  }
 }
 

--- a/src/stores/app.ts
+++ b/src/stores/app.ts
@@ -458,6 +458,81 @@ export const useAppStore = defineStore('app', () => {
     }
   }
 
+  async function copyJsonFile(file: JsonFile): Promise<boolean> {
+    logInfo('copyJsonFile called', { fileName: file.name, filePath: file.path })
+    try {
+      // Generate new path with "-复制" suffix
+      const pathParts = file.path.split('.')
+      const extension = pathParts.pop() || 'json'
+      const basePath = pathParts.join('.')
+      const newPath = `${basePath}-复制.${extension}`
+      
+      // Generate new name with "-复制" suffix
+      const nameParts = file.name.split('.')
+      const nameExtension = nameParts.pop() || 'json'
+      const baseName = nameParts.join('.')
+      const newName = `${baseName}-复制.${nameExtension}`
+
+      if (window.electronAPI?.copyFile) {
+        const result = await window.electronAPI.copyFile(file.path, newPath)
+        if (result.success && result.filePath) {
+          // Create new file object
+          const newFile: JsonFile = {
+            name: newName,
+            path: result.filePath,
+            content: file.content,
+            isValid: file.isValid,
+            errors: file.errors
+          }
+          
+          // Add to jsonFiles array
+          jsonFiles.value.push(newFile)
+          
+          // Add to current schema's associated files if applicable
+          if (currentSchema.value) {
+            const schemaIndex = schemas.value.findIndex(s => s.path === currentSchema.value!.path)
+            if (schemaIndex !== -1) {
+              schemas.value[schemaIndex].associatedFiles.push(newFile)
+            }
+          }
+          
+          // Save associations
+          await saveSchemaAssociations()
+          
+          logInfo('File copied successfully', { from: file.path, to: result.filePath })
+          return true
+        } else {
+          logError('Failed to copy file', result.error)
+          return false
+        }
+      } else {
+        // Web mode fallback
+        const newFile: JsonFile = {
+          name: newName,
+          path: newPath,
+          content: file.content,
+          isValid: file.isValid,
+          errors: file.errors
+        }
+        
+        jsonFiles.value.push(newFile)
+        
+        if (currentSchema.value) {
+          const schemaIndex = schemas.value.findIndex(s => s.path === currentSchema.value!.path)
+          if (schemaIndex !== -1) {
+            schemas.value[schemaIndex].associatedFiles.push(newFile)
+          }
+        }
+        
+        await saveSchemaAssociations()
+        return true
+      }
+    } catch (error) {
+      logError('Unexpected error in copyJsonFile', error)
+      return false
+    }
+  }
+
   async function saveSchemaAssociations(): Promise<void> {
     try {
       if (window.electronAPI && typeof window.electronAPI.writeConfigFile === 'function') {
@@ -599,6 +674,7 @@ export const useAppStore = defineStore('app', () => {
     deleteSchema,
     deleteJsonFile,
     renameJsonFile,
+    copyJsonFile,
     saveSchemaAssociations
   }
 })


### PR DESCRIPTION
Adds right-click 'Copy File' functionality for JSON files, appending '-复制' to the copied file's name.

---
Linear Issue: [MJ-37](https://linear.app/manyjson/issue/MJ-37/支持右键复制json文件功能)

<a href="https://cursor.com/background-agent?bcId=bc-baae565b-e5e3-4ffa-a47e-e8546bcbeebf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-baae565b-e5e3-4ffa-a47e-e8546bcbeebf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

