### PR TITLE
Update animations to use Apple easing curves

### DIFF
--- a/src/components/AddFilePopup.vue
+++ b/src/components/AddFilePopup.vue
@@ -278,7 +278,7 @@ watch(editContent, validateEditContent)
   justify-content: center;
   z-index: 1000;
   opacity: 0;
-  transition: opacity 0.3s ease;
+  transition: opacity 0.3s var(--apple-ease);
 }
 
 .popup-overlay.fade-in {
@@ -297,7 +297,7 @@ watch(editContent, validateEditContent)
   flex-direction: column;
   box-shadow: var(--apple-shadow-lg);
   transform: translateY(var(--spacing-lg)) scale(0.95); /* 20px */
-  transition: transform 0.3s ease;
+  transition: transform 0.3s var(--apple-ease);
 }
 
 .popup-window.slide-in {

--- a/src/components/JsonDiffViewer.vue
+++ b/src/components/JsonDiffViewer.vue
@@ -255,7 +255,7 @@ function closeDiff() {
   color: var(--linear-text-secondary);
   padding: 8px;
   border-radius: 6px;
-  transition: all 0.2s;
+  transition: all 0.2s var(--apple-ease);
 }
 
 .close-diff-btn:hover {

--- a/src/components/MiddlePanel.vue
+++ b/src/components/MiddlePanel.vue
@@ -312,7 +312,7 @@ onUnmounted(() => {
   border-radius: var(--radius-sm); /* 4px */
   outline: none;
   font-family: inherit;
-  transition: border-color 0.15s ease;
+  transition: border-color 0.15s var(--apple-ease);
 }
 
 /* Inline input inherits apple-input styling with overrides */

--- a/src/style.css
+++ b/src/style.css
@@ -92,8 +92,10 @@
   --apple-font-mono: 'SF Mono', 'Monaco', 'Cascadia Code', 'JetBrains Mono', monospace;
   
   /* Animation */
-  --apple-transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  --apple-transition-fast: all 0.15s cubic-bezier(0.4, 0, 0.2, 1);
+  --apple-ease: cubic-bezier(0.23, 1, 0.32, 1);
+  --apple-transition: all 0.3s var(--apple-ease);
+  --apple-transition-fast: all 0.15s var(--apple-ease);
+  --apple-spring-duration: 400ms;
   
   /* 8pt Grid System - Apple HIG Spacing Standards */
   --space-1: 4px;    /* 0.5 units */
@@ -1061,7 +1063,7 @@ body {
   height: 100%;
   background: var(--accent-primary);
   border-radius: 3px;
-  transition: width 0.3s ease;
+  transition: width 0.3s var(--apple-ease);
 }
 
 .apple-progress.indeterminate .apple-progress-bar {


### PR DESCRIPTION
Replace `ease` transitions with Apple's `cubic-bezier(0.23, 1, 0.32, 1)` easing curve to align with design guidelines (LC-72).

---
Linear Issue: [LC-72](https://linear.app/manyjson/issue/LC-72/replace-current-transitions-with-apples-easing-curves-ease-in-out)

<a href="https://cursor.com/background-agent?bcId=bc-d41f19fd-7ddc-43be-ad1e-f785c416748a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d41f19fd-7ddc-43be-ad1e-f785c416748a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

