### PR TITLE
Define tab resource data model

### DIFF
--- a/src/models/tabResource.ts
+++ b/src/models/tabResource.ts
@@ -1,0 +1,139 @@
+export type TabKey = string
+
+export interface TabResource {
+  key: TabKey
+  title: string
+  icon?: string
+  dirty: boolean
+  meta: Record<string, any>
+}
+
+export interface SerializedTabResource {
+  key: TabKey
+  title: string
+  icon?: string
+  dirty?: boolean
+  meta?: Record<string, any>
+}
+
+function assertValidKey(key: string): void {
+  if (typeof key !== 'string' || key.trim().length === 0) {
+    throw new Error('TabResource.key must be a non-empty string')
+  }
+}
+
+export function createTabResource(input: {
+  key: TabKey
+  title: string
+  icon?: string
+  dirty?: boolean
+  meta?: Record<string, any>
+}): TabResource {
+  assertValidKey(input.key)
+  if (typeof input.title !== 'string' || input.title.trim().length === 0) {
+    throw new Error('TabResource.title must be a non-empty string')
+  }
+
+  return {
+    key: input.key,
+    title: input.title,
+    icon: input.icon,
+    dirty: Boolean(input.dirty),
+    meta: input.meta ?? {}
+  }
+}
+
+export function serializeTabResource(resource: TabResource): SerializedTabResource {
+  assertValidKey(resource.key)
+  return {
+    key: resource.key,
+    title: resource.title,
+    icon: resource.icon,
+    dirty: resource.dirty || undefined,
+    meta: (resource.meta && Object.keys(resource.meta).length > 0) ? resource.meta : undefined
+  }
+}
+
+export function deserializeTabResource(serialized: SerializedTabResource): TabResource {
+  assertValidKey(serialized.key)
+  if (typeof serialized.title !== 'string' || serialized.title.trim().length === 0) {
+    throw new Error('Serialized TabResource.title must be a non-empty string')
+  }
+
+  return {
+    key: serialized.key,
+    title: serialized.title,
+    icon: serialized.icon,
+    dirty: Boolean(serialized.dirty),
+    meta: serialized.meta ?? {}
+  }
+}
+
+export function areTabResourcesEqual(a: TabResource, b: TabResource): boolean {
+  return a.key === b.key
+}
+
+export function validateUnique(resources: TabResource[]): { ok: boolean; duplicates: TabKey[] } {
+  const seen = new Set<TabKey>()
+  const duplicates: TabKey[] = []
+  for (const r of resources) {
+    assertValidKey(r.key)
+    if (seen.has(r.key)) {
+      duplicates.push(r.key)
+    } else {
+      seen.add(r.key)
+    }
+  }
+  return { ok: duplicates.length === 0, duplicates }
+}
+
+export class TabResourceRegistry {
+  private readonly keyToResource: Map<TabKey, TabResource>
+
+  constructor(initial?: TabResource[]) {
+    this.keyToResource = new Map<TabKey, TabResource>()
+    if (Array.isArray(initial)) {
+      for (const r of initial) {
+        this.add(r)
+      }
+    }
+  }
+
+  add(resource: TabResource): { added: boolean; resource: TabResource } {
+    assertValidKey(resource.key)
+    const existing = this.keyToResource.get(resource.key)
+    if (existing) {
+      return { added: false, resource: existing }
+    }
+    this.keyToResource.set(resource.key, resource)
+    return { added: true, resource }
+  }
+
+  addOrGet(resource: TabResource): TabResource {
+    return this.add(resource).resource
+  }
+
+  has(key: TabKey): boolean {
+    return this.keyToResource.has(key)
+  }
+
+  get(key: TabKey): TabResource | undefined {
+    return this.keyToResource.get(key)
+  }
+
+  remove(key: TabKey): boolean {
+    return this.keyToResource.delete(key)
+  }
+
+  clear(): void {
+    this.keyToResource.clear()
+  }
+
+  list(): TabResource[] {
+    return Array.from(this.keyToResource.values())
+  }
+
+  get size(): number {
+    return this.keyToResource.size
+  }
+}

--- a/test/tabResource.test.ts
+++ b/test/tabResource.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import { 
+  createTabResource,
+  serializeTabResource,
+  deserializeTabResource,
+  areTabResourcesEqual,
+  validateUnique,
+  TabResourceRegistry
+} from '../src/models/tabResource'
+
+describe('TabResource Model', () => {
+  it('creates a valid TabResource', () => {
+    const r = createTabResource({ key: 'file:/a.json', title: 'A', dirty: true, meta: { foo: 1 } })
+    expect(r.key).toBe('file:/a.json')
+    expect(r.title).toBe('A')
+    expect(r.dirty).toBe(true)
+    expect(r.meta).toEqual({ foo: 1 })
+  })
+
+  it('enforces non-empty key and title', () => {
+    expect(() => createTabResource({ key: '', title: 'x' })).toThrow()
+    expect(() => createTabResource({ key: 'k', title: '' })).toThrow()
+  })
+
+  it('serialize/deserialize round-trip equivalence', () => {
+    const original = createTabResource({ key: 'res:1', title: 'Title', dirty: false, meta: { a: true } })
+    const ser = serializeTabResource(original)
+    const back = deserializeTabResource(ser)
+    expect(areTabResourcesEqual(original, back)).toBe(true)
+    expect(back.title).toBe(original.title)
+    expect(back.icon).toBe(original.icon)
+    expect(back.dirty).toBe(original.dirty)
+    expect(back.meta).toEqual(original.meta)
+  })
+
+  it('omits empty optional fields on serialize', () => {
+    const r = createTabResource({ key: 'k', title: 'T' })
+    const ser = serializeTabResource(r)
+    expect(ser.dirty).toBeUndefined()
+    expect(ser.meta).toBeUndefined()
+  })
+})
+
+describe('TabResource uniqueness', () => {
+  it('validateUnique returns duplicates', () => {
+    const a = createTabResource({ key: 'x', title: 'X' })
+    const b = createTabResource({ key: 'y', title: 'Y' })
+    const c = createTabResource({ key: 'x', title: 'X2' })
+    const res = validateUnique([a, b, c])
+    expect(res.ok).toBe(false)
+    expect(res.duplicates).toEqual(['x'])
+  })
+
+  it('registry prevents duplicate add', () => {
+    const reg = new TabResourceRegistry()
+    const a = createTabResource({ key: 'k', title: 'T1' })
+    const first = reg.add(a)
+    expect(first.added).toBe(true)
+    expect(reg.size).toBe(1)
+
+    const second = reg.add(createTabResource({ key: 'k', title: 'T2' }))
+    expect(second.added).toBe(false)
+    expect(reg.size).toBe(1)
+    expect(second.resource.title).toBe('T1')
+  })
+
+  it('registry addOrGet returns existing instance', () => {
+    const reg = new TabResourceRegistry()
+    const a = createTabResource({ key: 'k', title: 'T1' })
+    const b = createTabResource({ key: 'k', title: 'T2' })
+    const first = reg.addOrGet(a)
+    const second = reg.addOrGet(b)
+    expect(first).toBe(second)
+    expect(reg.get('k')?.title).toBe('T1')
+  })
+})


### PR DESCRIPTION
Implements `TabResource` data model, serialization, and uniqueness validation as specified in LC-78.

---
Linear Issue: [LC-78](https://linear.app/manyjson/issue/LC-78/1-数据模型与类型)

<a href="https://cursor.com/background-agent?bcId=bc-1ecaac70-8b2f-4a6d-aec3-97bbc832d9fe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1ecaac70-8b2f-4a6d-aec3-97bbc832d9fe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

