### PR TITLE
Refactor project for web and desktop builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,18 +38,18 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build application
-        run: npm run build
+      - name: Build web application
+        run: npm run build:web
 
       - name: Build Electron app
         run: npm run electron:build
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Upload artifacts
+      - name: Upload web artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.platform }}-build
+          name: ${{ matrix.platform }}-web-dist
           path: dist/
 
   release:

--- a/README.md
+++ b/README.md
@@ -8,4 +8,22 @@ A modern JSON Schema and JSON File management application.
 - **File Management**: Organize and associate JSON files with schemas
 - **Syntax Highlighting**: Beautiful JSON syntax highlighting
 
+## Build Targets
+
+This project supports dual targets: Web and Desktop (Electron).
+
+- Web development: `npm run dev:web`
+- Desktop development: `npm run electron:dev`
+- Web production build: `npm run build:web`
+- Desktop production build: `npm run electron:build`
+
+Vite decides whether to include the Electron builder based on `BUILD_TARGET`. The HTML bootstraps `src/main-web.ts` or `src/main-desktop.ts` using `VITE_APP_TARGET`.
+
+### Platform Abstraction
+
+- Core code avoids direct `window.electronAPI` calls.
+- `src/platform/` provides interfaces and two adapters:
+  - `web.ts`: Browser fallback implementations and capabilities
+  - `desktop.ts`: Electron-backed implementations via preload APIs
+- Use `useCapability()` to check features and handle downgrade prompts.
 

--- a/index.html
+++ b/index.html
@@ -9,6 +9,11 @@
 </head>
 <body>
   <div id="app"></div>
-  <script type="module" src="/src/main.ts"></script>
+  <script type="module">
+    // Choose entry based on environment variable injected at build time
+    const target = import.meta.env?.VITE_APP_TARGET || (window.electronAPI ? 'desktop' : 'web')
+    const entry = target === 'desktop' ? '/src/main-desktop.ts' : '/src/main-web.ts'
+    import(entry)
+  </script>
 </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "manyjson-vue",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "manyjson-vue",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
         "@codemirror/highlight": "^0.19.8",
         "@codemirror/lang-json": "^6.0.2",
@@ -25,6 +25,7 @@
         "@vitejs/plugin-vue": "^4.5.0",
         "@vue/tsconfig": "^0.5.0",
         "concurrently": "^8.2.0",
+        "cross-env": "^7.0.3",
         "electron": "^28.3.3",
         "electron-builder": "^24.13.3",
         "jsdom": "^26.1.0",
@@ -3152,6 +3153,25 @@
       "resolved": "https://registry.npmmirror.com/crelt/-/crelt-1.0.6.tgz",
       "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
       "license": "MIT"
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -6,11 +6,15 @@
   "main": "dist-electron/main.js",
   "scripts": {
     "dev": "vite",
+    "dev:web": "cross-env VITE_APP_TARGET=web BUILD_TARGET=web vite",
+    "dev:desktop": "cross-env VITE_APP_TARGET=desktop BUILD_TARGET=desktop vite",
     "build": "vite build",
+    "build:web": "cross-env VITE_APP_TARGET=web BUILD_TARGET=web vite build",
+    "build:desktop": "cross-env VITE_APP_TARGET=desktop BUILD_TARGET=desktop vite build",
     "preview": "vite preview",
     "electron": "electron .",
-    "electron:dev": "concurrently \"npm run dev\" \"wait-on http://localhost:5173 && electron .\"",
-    "electron:build": "npm run build && electron-builder",
+    "electron:dev": "concurrently \"npm run dev:desktop\" \"wait-on http://localhost:5173 && electron .\"",
+    "electron:build": "npm run build:desktop && electron-builder",
     "test": "vitest",
     "test:ui": "vitest --ui",
     "clean": "rm -rf node_modules dist dist-electron out release"
@@ -87,6 +91,7 @@
     "vue-router": "^4.5.1"
   },
   "devDependencies": {
+    "cross-env": "^7.0.3",
     "@types/node": "^20.10.0",
     "@vitejs/plugin-vue": "^4.5.0",
     "@vue/tsconfig": "^0.5.0",

--- a/src/components/AddSchemaDialog.vue
+++ b/src/components/AddSchemaDialog.vue
@@ -63,10 +63,12 @@ import { ref, computed, watch } from 'vue'
 import { useAppStore } from '@/stores/app'
 import { useUIStore } from '@/stores/ui'
 import { useSchemaManager } from '@/composables/useSchemaManager'
+import { useCapability } from '@/composables/useCapability'
 
 const appStore = useAppStore()
 const ui = useUIStore()
 const manager = useSchemaManager()
+const { runtime } = useCapability()
 
 const isVisible = ref(false)
 const schemaName = ref('')
@@ -275,7 +277,7 @@ async function handleSubmit() {
     schemaName: schemaName.value,
     contentLength: schemaContentText.value.length,
     hasValidContent: !!parsedContent.value,
-    hasElectronAPI: !!window.electronAPI
+    platform: runtime.name
   })
   
   if (!validateForm()) {
@@ -288,10 +290,8 @@ async function handleSubmit() {
   try {
     logInfo('Calling appStore.addSchema')
     
-    // Check if electronAPI is available
-    if (!window.electronAPI) {
-      logError('electronAPI is not available - running in web mode')
-      ui.showStatus('Running in web mode - schemas will not be saved permanently', 'info')
+    if (runtime.name === 'web') {
+      ui.showStatus('Web 模式：数据仅临时保存。桌面版支持持久化。', 'info')
     }
 
     const success = await manager.addSchema(schemaName.value, parsedContent.value)
@@ -314,7 +314,7 @@ async function handleSubmit() {
     logError('Detailed error info', {
       message: errorMessage,
       stack: errorDetails,
-      hasElectronAPI: !!window.electronAPI,
+      platform: runtime.name,
       schemaName: schemaName.value,
       contentLength: schemaContentText.value.length
     })

--- a/src/components/RightPanel.vue
+++ b/src/components/RightPanel.vue
@@ -143,6 +143,7 @@ import JsonHighlight from './JsonHighlight.vue'
 import AdvancedJsonEditor from './AdvancedJsonEditor.vue'
 import JsonDiffViewer from './JsonDiffViewer.vue'
 import CopyIcon from './icons/CopyIcon.vue'
+import { useCapability } from '@/composables/useCapability'
 import EditIcon from './icons/EditIcon.vue'
 import SaveIcon from './icons/SaveIcon.vue'
 import CancelIcon from './icons/CancelIcon.vue'
@@ -151,6 +152,7 @@ const appStore = useAppStore()
 const ui = useUIStore()
 const validationService = new ValidationService()
 const fileService = new FileService()
+const { copyText } = useCapability()
 const editContent = ref('')
 const editErrors = ref<any[]>([])
 const editSchemaContent = ref('')
@@ -283,7 +285,7 @@ async function copyToClipboard() {
   
   try {
     const content = JSON.stringify(appStore.currentJsonFile.content, null, 2)
-    await navigator.clipboard.writeText(content)
+    await copyText(content)
     ui.showStatus('JSON copied to clipboard', 'success')
   } catch (error) {
     ui.showStatus('Failed to copy to clipboard', 'error')
@@ -295,7 +297,7 @@ async function copySchemaToClipboard() {
   
   try {
     const content = JSON.stringify(appStore.currentSchema.content, null, 2)
-    await navigator.clipboard.writeText(content)
+    await copyText(content)
     ui.showStatus('Schema copied to clipboard', 'success')
   } catch (error) {
     ui.showStatus('Failed to copy schema to clipboard', 'error')

--- a/src/composables/useCapability.ts
+++ b/src/composables/useCapability.ts
@@ -1,0 +1,22 @@
+import { computed } from 'vue'
+import { getPlatformRuntime } from '@/platform/runtime'
+
+export function useCapability() {
+	const runtime = getPlatformRuntime()
+
+	function is(cap: keyof typeof runtime.capabilities) {
+		return runtime.capabilities[cap]
+	}
+
+	async function copyText(text: string) {
+		return runtime.apis.writeClipboardText(text)
+	}
+
+	return {
+		runtime,
+		is,
+		copyText,
+		name: computed(() => runtime.name)
+	}
+}
+

--- a/src/main-desktop.ts
+++ b/src/main-desktop.ts
@@ -1,0 +1,27 @@
+import { createApp } from 'vue'
+import { createPinia } from 'pinia'
+import { createRouter, createWebHashHistory } from 'vue-router'
+import App from './App.vue'
+import './style.css'
+import { useUIStore } from './stores/ui'
+
+const router = createRouter({
+	history: createWebHashHistory(),
+	routes: [
+		{ path: '/', name: 'Home', component: () => import('./views/Home.vue') },
+		{ path: '/schema/:schemaName', name: 'Schema', component: () => import('./views/Home.vue') },
+		{ path: '/schema/:schemaName/file/:fileName', name: 'SchemaFile', component: () => import('./views/Home.vue') }
+	]
+})
+
+const pinia = createPinia()
+const app = createApp(App)
+app.use(pinia)
+app.use(router)
+app.mount('#app')
+
+const uiStore = useUIStore()
+uiStore.initializeTheme()
+uiStore.initializeLayout()
+uiStore.initializeKeyboardShortcuts()
+

--- a/src/main-web.ts
+++ b/src/main-web.ts
@@ -1,0 +1,27 @@
+import { createApp } from 'vue'
+import { createPinia } from 'pinia'
+import { createRouter, createWebHashHistory } from 'vue-router'
+import App from './App.vue'
+import './style.css'
+import { useUIStore } from './stores/ui'
+
+const router = createRouter({
+	history: createWebHashHistory(),
+	routes: [
+		{ path: '/', name: 'Home', component: () => import('./views/Home.vue') },
+		{ path: '/schema/:schemaName', name: 'Schema', component: () => import('./views/Home.vue') },
+		{ path: '/schema/:schemaName/file/:fileName', name: 'SchemaFile', component: () => import('./views/Home.vue') }
+	]
+})
+
+const pinia = createPinia()
+const app = createApp(App)
+app.use(pinia)
+app.use(router)
+app.mount('#app')
+
+const uiStore = useUIStore()
+uiStore.initializeTheme()
+uiStore.initializeLayout()
+uiStore.initializeKeyboardShortcuts()
+

--- a/src/platform/desktop.ts
+++ b/src/platform/desktop.ts
@@ -1,0 +1,54 @@
+import type {
+	PlatformApis,
+	WriteResult,
+	ListDirectoryEntry,
+	PlatformCapabilities
+} from './index'
+
+const electronAPI = (typeof window !== 'undefined' ? (window as any).electronAPI : undefined)
+
+const desktopCapabilities: PlatformCapabilities = {
+	fileSystem: true,
+	configStorage: true,
+	structuredStorage: true,
+	openDialog: true,
+	saveDialog: true,
+	clipboard: true
+}
+
+export const DesktopPlatformApis: PlatformApis = {
+	async readFile(filePath) { return electronAPI.readFile(filePath) },
+	async readTextFile(filePath) { return electronAPI.readTextFile(filePath) },
+	async writeJsonFile(filePath, content): Promise<WriteResult> { return electronAPI.writeJsonFile(filePath, content) },
+	async deleteFile(filePath): Promise<WriteResult> { return electronAPI.deleteFile(filePath) },
+	async renameFile(oldPath, newPath): Promise<WriteResult> { return electronAPI.renameFile?.(oldPath, newPath) ?? { success: false, error: 'renameFile not implemented in preload' } },
+	async copyFile(filePath, newPath): Promise<WriteResult> { return electronAPI.copyFile?.(filePath, newPath) ?? { success: false, error: 'copyFile not implemented in preload' } },
+	async getFileStats(filePath) { return electronAPI.getFileStats(filePath) },
+	async listDirectory(dirPath): Promise<{ success: boolean; entries?: ListDirectoryEntry[]; error?: string }> { return electronAPI.listDirectory(dirPath) },
+
+	async getConfigDirectory() { return electronAPI.getConfigDirectory() },
+	async writeConfigFile(fileName, content) { return electronAPI.writeConfigFile(fileName, content) },
+	async listConfigFiles() { return electronAPI.listConfigFiles() },
+
+	async writeSchemaJsonFile(schemaName, fileName, content) { return electronAPI.writeSchemaJsonFile?.(schemaName, fileName, content) ?? { success: false, error: 'writeSchemaJsonFile not implemented' } },
+	async listSchemaJsonFiles(schemaName) { return electronAPI.listSchemaJsonFiles?.(schemaName) ?? { success: true, files: [] } },
+
+	async showOpenDialog(options) { return electronAPI.showOpenDialog(options) },
+	async showSaveDialog(options) { return electronAPI.showSaveDialog(options) },
+
+	async writeClipboardText(text: string) {
+		try {
+			await navigator.clipboard.writeText(text)
+			return { success: true }
+		} catch (e: any) {
+			return { success: false, error: String(e) }
+		}
+	},
+
+	isCapabilityAvailable(cap: keyof typeof desktopCapabilities) {
+		return desktopCapabilities[cap]
+	}
+}
+
+export { desktopCapabilities }
+

--- a/src/platform/index.ts
+++ b/src/platform/index.ts
@@ -1,0 +1,89 @@
+export type PlatformName = 'web' | 'desktop'
+
+export interface FileStats {
+	isFile: boolean
+	isDirectory: boolean
+	size?: number
+	modified?: Date
+}
+
+export interface FileDialogOptions {
+	title?: string
+	filters?: Array<{ name: string; extensions: string[] }>
+	properties?: string[]
+}
+
+export interface SaveDialogOptions {
+	title?: string
+	defaultPath?: string
+	filters?: Array<{ name: string; extensions: string[] }>
+}
+
+export interface WriteResult {
+	success: boolean
+	filePath?: string
+	error?: string
+}
+
+export interface ListDirectoryEntry {
+	name: string
+	path: string
+	isFile: boolean
+	isDirectory: boolean
+	size: number
+	modified: Date
+}
+
+export interface PlatformApis {
+	// Files
+	readFile<T = any>(filePath: string): Promise<{ success: boolean; data?: T; error?: string }>
+	readTextFile(filePath: string): Promise<{ success: boolean; content?: string; error?: string }>
+	writeJsonFile(filePath: string, content: string): Promise<WriteResult>
+	deleteFile(filePath: string): Promise<WriteResult>
+	renameFile(oldPath: string, newPath: string): Promise<WriteResult>
+	copyFile(filePath: string, newPath: string): Promise<WriteResult>
+	getFileStats(filePath: string): Promise<{ success: boolean; error?: string } & Partial<FileStats>>
+	listDirectory(dirPath: string): Promise<{ success: boolean; entries?: ListDirectoryEntry[]; error?: string }>
+
+	// App config storage
+	getConfigDirectory(): Promise<{ success: boolean; path?: string; error?: string }>
+	writeConfigFile(fileName: string, content: string): Promise<WriteResult>
+	listConfigFiles(): Promise<{ success: boolean; files?: Array<{ name: string; path: string; content: any }>; error?: string }>
+
+	// Structured JSON storage
+	writeSchemaJsonFile(schemaName: string, fileName: string, content: string): Promise<WriteResult>
+	listSchemaJsonFiles(schemaName: string): Promise<{ success: boolean; files?: Array<{ name: string; path: string; content: any }>; error?: string }>
+
+	// Dialogs
+	showOpenDialog(options: FileDialogOptions): Promise<{ canceled: boolean; filePaths: string[] }>
+	showSaveDialog(options: SaveDialogOptions): Promise<{ canceled: boolean; filePath?: string }>
+
+	// Clipboard
+	writeClipboardText(text: string): Promise<{ success: boolean; error?: string }>
+
+	// Capabilities
+	isCapabilityAvailable(cap: keyof PlatformCapabilities): boolean
+}
+
+export interface PlatformCapabilities {
+	fileSystem: boolean
+	configStorage: boolean
+	structuredStorage: boolean
+	openDialog: boolean
+	saveDialog: boolean
+	clipboard: boolean
+}
+
+export interface PlatformRuntime {
+	name: PlatformName
+	capabilities: PlatformCapabilities
+	apis: PlatformApis
+}
+
+// Environment detection
+export function detectPlatform(): PlatformName {
+	// If preload exposed electronAPI, assume desktop
+	if (typeof window !== 'undefined' && (window as any).electronAPI) return 'desktop'
+	return 'web'
+}
+

--- a/src/platform/runtime.ts
+++ b/src/platform/runtime.ts
@@ -1,0 +1,12 @@
+import { detectPlatform } from './index'
+import { WebPlatformApis, webCapabilities } from './web'
+import { DesktopPlatformApis, desktopCapabilities } from './desktop'
+
+export function getPlatformRuntime() {
+	const name = detectPlatform()
+	if (name === 'desktop') {
+		return { name, capabilities: desktopCapabilities, apis: DesktopPlatformApis }
+	}
+	return { name, capabilities: webCapabilities, apis: WebPlatformApis }
+}
+

--- a/src/platform/web.ts
+++ b/src/platform/web.ts
@@ -1,0 +1,54 @@
+import type {
+	PlatformApis,
+	WriteResult,
+	ListDirectoryEntry,
+	PlatformCapabilities
+} from './index'
+
+const unsupported = (feature: string) => ({ success: false, error: `${feature} not available in web mode` })
+
+const webCapabilities: PlatformCapabilities = {
+	fileSystem: false,
+	configStorage: false,
+	structuredStorage: false,
+	openDialog: false,
+	saveDialog: false,
+	clipboard: true
+}
+
+export const WebPlatformApis: PlatformApis = {
+	async readFile() { return { success: false, error: 'readFile not available in web mode' } },
+	async readTextFile() { return { success: false, error: 'readTextFile not available in web mode' } },
+	async writeJsonFile(filePath: string, _content: string): Promise<WriteResult> { return { success: true, filePath } },
+	async deleteFile(): Promise<WriteResult> { return { success: true } },
+	async renameFile(_old, _new): Promise<WriteResult> { return { success: true } },
+	async copyFile(_src, _dst): Promise<WriteResult> { return { success: true } },
+	async getFileStats() { return { success: false, error: 'getFileStats not available in web mode' } },
+	async listDirectory(_dir): Promise<{ success: boolean; entries?: ListDirectoryEntry[]; error?: string }> { return { success: false, error: 'listDirectory not available in web mode' } },
+
+	async getConfigDirectory() { return unsupported('getConfigDirectory') },
+	async writeConfigFile(_n, _c) { return { success: true } },
+	async listConfigFiles() { return { success: true, files: [] } },
+
+	async writeSchemaJsonFile(_s, _f, _c) { return { success: true } },
+	async listSchemaJsonFiles(_s) { return { success: true, files: [] } },
+
+	async showOpenDialog() { return { canceled: true, filePaths: [] } },
+	async showSaveDialog() { return { canceled: true } },
+
+	async writeClipboardText(text: string) {
+		try {
+			await navigator.clipboard.writeText(text)
+			return { success: true }
+		} catch (e: any) {
+			return { success: false, error: String(e) }
+		}
+	},
+
+	isCapabilityAvailable(cap: keyof typeof webCapabilities) {
+		return webCapabilities[cap]
+	}
+}
+
+export { webCapabilities }
+

--- a/src/services/fileService.ts
+++ b/src/services/fileService.ts
@@ -10,115 +10,81 @@ export interface FileInfo<T = any> {
   content: T
 }
 
+import { getPlatformRuntime } from '@/platform/runtime'
+
 export class FileService {
+  private apis = getPlatformRuntime().apis
+
   async writeJsonFile(filePath: string, content: string): Promise<WriteResult> {
-    if (window.electronAPI?.writeJsonFile) {
-      try {
-        const result = await window.electronAPI.writeJsonFile(filePath, content)
-        return result
-      } catch (error: any) {
-        return { success: false, error: String(error) }
-      }
+    try {
+      return await this.apis.writeJsonFile(filePath, content)
+    } catch (error: any) {
+      return { success: false, error: String(error) }
     }
-    return { success: true, filePath }
   }
 
   async deleteFile(filePath: string): Promise<WriteResult> {
-    if (window.electronAPI?.deleteFile) {
-      try {
-        const result = await window.electronAPI.deleteFile(filePath)
-        return result
-      } catch (error: any) {
-        return { success: false, error: String(error) }
-      }
+    try {
+      return await this.apis.deleteFile(filePath)
+    } catch (error: any) {
+      return { success: false, error: String(error) }
     }
-    return { success: true }
   }
 
   async writeConfigFile(fileName: string, content: string): Promise<WriteResult> {
-    if (window.electronAPI?.writeConfigFile) {
-      try {
-        const result = await window.electronAPI.writeConfigFile(fileName, content)
-        return result
-      } catch (error: any) {
-        return { success: false, error: String(error) }
-      }
+    try {
+      return await this.apis.writeConfigFile(fileName, content)
+    } catch (error: any) {
+      return { success: false, error: String(error) }
     }
-    return { success: true, filePath: `mock:///${fileName}` }
   }
 
   async listConfigFiles(): Promise<{ success: boolean; files?: FileInfo[]; error?: string }> {
-    if (window.electronAPI?.listConfigFiles) {
-      try {
-        const result = await window.electronAPI.listConfigFiles()
-        return result
-      } catch (error: any) {
-        return { success: false, error: String(error) }
-      }
+    try {
+      return await this.apis.listConfigFiles()
+    } catch (error: any) {
+      return { success: false, error: String(error) }
     }
-    return { success: true, files: [] }
   }
 
   async readFile<T = any>(filePath: string): Promise<{ success: boolean; data?: T; error?: string }> {
-    if (window.electronAPI?.readFile) {
-      try {
-        const result = await window.electronAPI.readFile(filePath)
-        return result
-      } catch (error: any) {
-        return { success: false, error: String(error) }
-      }
+    try {
+      return await this.apis.readFile<T>(filePath)
+    } catch (error: any) {
+      return { success: false, error: String(error) }
     }
-    return { success: false, error: 'readFile not available in web mode' }
   }
 
   async writeSchemaJsonFile(schemaName: string, fileName: string, content: string): Promise<WriteResult> {
-    if (window.electronAPI?.writeSchemaJsonFile) {
-      try {
-        const result = await window.electronAPI.writeSchemaJsonFile(schemaName, fileName, content)
-        return result
-      } catch (error: any) {
-        return { success: false, error: String(error) }
-      }
+    try {
+      return await this.apis.writeSchemaJsonFile(schemaName, fileName, content)
+    } catch (error: any) {
+      return { success: false, error: String(error) }
     }
-    return { success: true, filePath: `mock://${schemaName}/${fileName}` }
   }
 
   async listSchemaJsonFiles(schemaName: string): Promise<{ success: boolean; files?: FileInfo[]; error?: string }> {
-    if (window.electronAPI?.listSchemaJsonFiles) {
-      try {
-        const result = await window.electronAPI.listSchemaJsonFiles(schemaName)
-        return result
-      } catch (error: any) {
-        return { success: false, error: String(error) }
-      }
+    try {
+      return await this.apis.listSchemaJsonFiles(schemaName) as any
+    } catch (error: any) {
+      return { success: false, error: String(error) }
     }
-    return { success: true, files: [] }
   }
 
   async renameFile(oldPath: string, newPath: string): Promise<WriteResult> {
-    if (window.electronAPI?.renameFile) {
-      try {
-        const result = await window.electronAPI.renameFile(oldPath, newPath)
-        return result
-      } catch (error: any) {
-        return { success: false, error: String(error) }
-      }
+    try {
+      return await this.apis.renameFile(oldPath, newPath)
+    } catch (error: any) {
+      return { success: false, error: String(error) }
     }
-    // Web mode fallback: pretend success
-    return { success: true, filePath: newPath }
   }
 
   async copyFile(filePath: string, newPath: string): Promise<WriteResult> {
-    if (window.electronAPI?.copyFile) {
-      try {
-        const result = await window.electronAPI.copyFile(filePath, newPath)
-        return result
-      } catch (error: any) {
-        return { success: false, error: String(error) }
-      }
+    try {
+      return await this.apis.copyFile(filePath, newPath)
+    } catch (error: any) {
+      return { success: false, error: String(error) }
     }
-    // Web mode fallback: pretend success
-    return { success: true, filePath: newPath }
   }
 }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,53 +3,60 @@ import vue from '@vitejs/plugin-vue'
 import electron from 'vite-plugin-electron'
 import { resolve } from 'path'
 
-export default defineConfig({
-  plugins: [
-    vue(),
-    electron([
-      {
-        entry: 'electron/main.ts',
-        onstart(args) {
-          args.startup()
-        },
-        vite: {
-          build: {
-            outDir: 'dist-electron',
-            lib: {
-              entry: 'electron/main.ts',
-              formats: ['cjs']
-            },
-            rollupOptions: {
-              external: ['electron']
-            }
-          }
-        }
-      },
-      {
-        entry: 'electron/preload.ts',
-        onstart(args) {
-          args.reload()
-        },
-        vite: {
-          build: {
-            outDir: 'dist-electron',
-            lib: {
-              entry: 'electron/preload.ts',
-              formats: ['cjs']
-            }
-          }
-        }
+export default defineConfig(({ mode }) => {
+  const isDesktop = process.env.BUILD_TARGET === 'desktop'
+  return {
+    plugins: [
+      vue(),
+      ...(isDesktop
+        ? [
+            electron([
+              {
+                entry: 'electron/main.ts',
+                onstart(args) {
+                  args.startup()
+                },
+                vite: {
+                  build: {
+                    outDir: 'dist-electron',
+                    lib: {
+                      entry: 'electron/main.ts',
+                      formats: ['cjs']
+                    },
+                    rollupOptions: {
+                      external: ['electron']
+                    }
+                  }
+                }
+              },
+              {
+                entry: 'electron/preload.ts',
+                onstart(args) {
+                  args.reload()
+                },
+                vite: {
+                  build: {
+                    outDir: 'dist-electron',
+                    lib: {
+                      entry: 'electron/preload.ts',
+                      formats: ['cjs']
+                    }
+                  }
+                }
+              }
+            ])
+          ]
+        : [])
+    ],
+    resolve: {
+      alias: {
+        '@': resolve(__dirname, 'src')
       }
-    ])
-  ],
-  resolve: {
-    alias: {
-      '@': resolve(__dirname, 'src')
+    },
+    base: './',
+    build: {
+      outDir: 'dist',
+      emptyOutDir: true
     }
-  },
-  base: './',
-  build: {
-    outDir: 'dist',
-    emptyOutDir: true
   }
 })


### PR DESCRIPTION
Implement a platform abstraction layer to enable dual web and desktop builds, addressing Linear issue LC-85.

This PR introduces a `src/platform` layer with distinct web and desktop adapters, refactors core components to use these platform-agnostic APIs, and updates the build system to support separate `web` and `desktop` targets. This allows the application to be built and run as a standard web application while maintaining full desktop functionality.

---
Linear Issue: [LC-85](https://linear.app/manyjson/issue/LC-85/支持构建普通web应用)

<a href="https://cursor.com/background-agent?bcId=bc-66f96511-9a43-4657-bd14-b5667d750182">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-66f96511-9a43-4657-bd14-b5667d750182">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

