### PR TITLE
Enable web schema read/write from disk

### DIFF
--- a/src/components/RightPanel.vue
+++ b/src/components/RightPanel.vue
@@ -217,6 +217,10 @@ async function saveChanges() {
       appStore.currentJsonFile.content = parsedContent
       appStore.currentJsonFile.isValid = true
       appStore.currentJsonFile.errors = []
+      if (result.filePath && result.filePath !== appStore.currentJsonFile.path) {
+        // Update path if web save returned a new fs:// path
+        appStore.currentJsonFile.path = result.filePath
+      }
       ui.setEditMode(false)
     } else {
       ui.showStatus(`Failed to save file: ${result.error || 'Unknown error'}`, 'error')
@@ -268,6 +272,11 @@ async function saveSchemaChanges() {
     if (result.success) {
       // Update the current schema content
       appStore.currentSchema.content = parsedContent
+      if (result.filePath && result.filePath !== appStore.currentSchema.path) {
+        appStore.currentSchema.path = result.filePath
+        // Persist updated schema path in web mode
+        try { (appStore as any).persistSchemasWeb?.() } catch {}
+      }
       ui.setSchemaEditMode(false)
       
       // Reload schemas to refresh the UI

--- a/src/platform/web.ts
+++ b/src/platform/web.ts
@@ -7,19 +7,139 @@ import type {
 
 const unsupported = (feature: string) => ({ success: false, error: `${feature} not available in web mode` })
 
+// In-memory handle registry for File System Access API
+const handleRegistry = new Map<string, FileSystemFileHandle>()
+
+function randomId(): string {
+	return Math.random().toString(36).slice(2) + Date.now().toString(36)
+}
+
+function toFsUri(id: string, name: string): string {
+	return `fs://${id}/${name}`
+}
+
+function parseFsUri(uri: string): { id: string; name: string } | null {
+	try {
+		if (!uri.startsWith('fs://')) return null
+		const withoutScheme = uri.slice('fs://'.length)
+		const firstSlash = withoutScheme.indexOf('/')
+		if (firstSlash === -1) return null
+		const id = withoutScheme.slice(0, firstSlash)
+		const name = withoutScheme.slice(firstSlash + 1)
+		return { id, name }
+	} catch {
+		return null
+	}
+}
+
 const webCapabilities: PlatformCapabilities = {
-	fileSystem: false,
+	fileSystem: typeof (window as any).showOpenFilePicker === 'function',
 	configStorage: false,
 	structuredStorage: false,
-	openDialog: false,
-	saveDialog: false,
+	openDialog: typeof (window as any).showOpenFilePicker === 'function',
+	saveDialog: typeof (window as any).showSaveFilePicker === 'function',
 	clipboard: true
 }
 
+async function readHandleText(handle: FileSystemFileHandle): Promise<string> {
+	const file = await handle.getFile()
+	return await file.text()
+}
+
+async function writeHandleText(handle: FileSystemFileHandle, content: string): Promise<void> {
+	const writable = await handle.createWritable()
+	await writable.write(content)
+	await writable.close()
+}
+
 export const WebPlatformApis: PlatformApis = {
-	async readFile() { return { success: false, error: 'readFile not available in web mode' } },
-	async readTextFile() { return { success: false, error: 'readTextFile not available in web mode' } },
-	async writeJsonFile(filePath: string, _content: string): Promise<WriteResult> { return { success: true, filePath } },
+	async readFile<T = any>(filePath: string) {
+		const parsed = parseFsUri(filePath)
+		if (!parsed) return { success: false, error: 'Unsupported path in web mode' }
+		const handle = handleRegistry.get(parsed.id)
+		if (!handle) return { success: false, error: 'File handle not found (permission not granted or expired)' }
+		try {
+			const text = await readHandleText(handle)
+			try {
+				const data = JSON.parse(text) as T
+				return { success: true, data }
+			} catch {
+				return { success: true, data: text as unknown as T }
+			}
+		} catch (e: any) {
+			return { success: false, error: String(e) }
+		}
+	},
+
+	async readTextFile(filePath: string) {
+		const parsed = parseFsUri(filePath)
+		if (!parsed) return { success: false, error: 'Unsupported path in web mode' }
+		const handle = handleRegistry.get(parsed.id)
+		if (!handle) return { success: false, error: 'File handle not found (permission not granted or expired)' }
+		try {
+			const content = await readHandleText(handle)
+			return { success: true, content }
+		} catch (e: any) {
+			return { success: false, error: String(e) }
+		}
+	},
+
+	async writeJsonFile(filePath: string, content: string): Promise<WriteResult> {
+		// Try writing to existing handle if provided as fs:// URI
+		const parsed = parseFsUri(filePath)
+		if (parsed) {
+			const existing = handleRegistry.get(parsed.id)
+			if (existing) {
+				try {
+					await writeHandleText(existing, content)
+					return { success: true, filePath }
+				} catch (e: any) {
+					return { success: false, error: String(e) }
+				}
+			}
+		}
+
+		// Otherwise prompt user to pick a save location
+		if (typeof (window as any).showSaveFilePicker === 'function') {
+			try {
+				const suggestedName = (() => {
+					try {
+						const p = new URL(filePath)
+						return p.pathname.split('/').pop() || 'schema.json'
+					} catch {
+						return filePath.split('/').pop() || 'schema.json'
+					}
+				})()
+				// @ts-ignore - types available in supporting browsers
+				const handle: FileSystemFileHandle = await (window as any).showSaveFilePicker({
+					suggestedName,
+					types: [{ description: 'JSON Files', accept: { 'application/json': ['.json'] } }]
+				})
+				await writeHandleText(handle, content)
+				const id = randomId()
+				handleRegistry.set(id, handle)
+				const uri = toFsUri(id, suggestedName)
+				return { success: true, filePath: uri }
+			} catch (e: any) {
+				return { success: false, error: String(e) }
+			}
+		}
+
+		// Fallback: trigger download
+		try {
+			const blob = new Blob([content], { type: 'application/json' })
+			const a = document.createElement('a')
+			const url = URL.createObjectURL(blob)
+			a.href = url
+			a.download = filePath.split('/').pop() || 'schema.json'
+			a.click()
+			URL.revokeObjectURL(url)
+			return { success: true, filePath }
+		} catch (e: any) {
+			return { success: false, error: String(e) }
+		}
+	},
+
 	async deleteFile(): Promise<WriteResult> { return { success: true } },
 	async renameFile(_old, _new): Promise<WriteResult> { return { success: true } },
 	async copyFile(_src, _dst): Promise<WriteResult> { return { success: true } },
@@ -33,8 +153,36 @@ export const WebPlatformApis: PlatformApis = {
 	async writeSchemaJsonFile(_s, _f, _c) { return { success: true } },
 	async listSchemaJsonFiles(_s) { return { success: true, files: [] } },
 
-	async showOpenDialog() { return { canceled: true, filePaths: [] } },
-	async showSaveDialog() { return { canceled: true } },
+	async showOpenDialog(options) {
+		if (typeof (window as any).showOpenFilePicker !== 'function') {
+			return { canceled: true, filePaths: [] }
+		}
+		try {
+			// Map filters to types
+			const types = options?.filters?.length
+				? options.filters.map(f => ({ description: f.name, accept: { 'application/json': f.extensions.map(ext => ext.startsWith('.') ? ext : `.${ext}`) } }))
+				: [{ description: 'JSON Files', accept: { 'application/json': ['.json'] } }]
+			// @ts-ignore
+			const handles: FileSystemFileHandle[] = await (window as any).showOpenFilePicker({
+				multiple: true,
+				types
+			})
+			const filePaths: string[] = []
+			for (const handle of handles) {
+				const id = randomId()
+				handleRegistry.set(id, handle)
+				filePaths.push(toFsUri(id, (handle as any).name || 'untitled.json'))
+			}
+			return { canceled: false, filePaths }
+		} catch (e: any) {
+			return { canceled: true, filePaths: [] }
+		}
+	},
+
+	async showSaveDialog() {
+		// Saving is handled inside writeJsonFile for web mode
+		return { canceled: true }
+	},
 
 	async writeClipboardText(text: string) {
 		try {


### PR DESCRIPTION
Add support for reading and writing user schemas from/to disk in web mode using the File System Access API.

This PR implements the ability for web users to import and save schemas directly to their local file system, addressing Linear issue LC-89. It utilizes the File System Access API for direct interaction in supporting browsers, with a fallback to file download for saving when the API is unavailable. Schema metadata is persisted in `localStorage` for web sessions, though file handles require re-authorization upon browser refresh.

---
Linear Issue: [LC-89](https://linear.app/manyjson/issue/LC-89/支持web模式读取用户磁盘上的schema和写入用户磁盘上的schema)

<a href="https://cursor.com/background-agent?bcId=bc-c3810a42-287c-4c7a-949d-1ee013265806">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c3810a42-287c-4c7a-949d-1ee013265806">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

