### PR TITLE
Optimize mobile display for schema viewing

### DIFF
--- a/doc/LC-92_MOBILE_VIEW_ONLY.md
+++ b/doc/LC-92_MOBILE_VIEW_ONLY.md
@@ -1,0 +1,88 @@
+# LC-92 优化手机端/小屏幕展示效果（仅展示模式）
+
+## 目标
+- 在移动端（宽度 ≤ 767px）与小屏幕上仅支持“查看”，不支持“编辑/新建/比较”等操作。
+- 用户可以：
+  - 从左侧选择一个 Schema；
+  - 在中间面板点选该 Schema 下的 JSON 文件；
+  - 在右侧查看 Schema 定义或 JSON 文件内容；
+  - 可拷贝内容到剪贴板。
+
+## 范围与约束
+- 所有文档读取/撰写均基于 `/doc` 目录。
+- 移动端仅展示，不提供：
+  - 新建 Schema / 导入 Schema / 新建 JSON 文件；
+  - JSON 编辑、Schema 编辑；
+  - Diff 比较视图；
+  - 右键上下文菜单；
+  - 面板拖拽分隔条。
+
+## 设计
+1. 新增响应式状态
+   - 在 `src/stores/ui.ts` 中新增 `isMobile`，并提供 `initializeResponsive()`。
+   - 依据窗口宽度（≤ 767px）设置 `isMobile`。
+
+2. 组件层行为调整（当 `ui.isMobile === true`）
+   - `views/Home.vue`
+     - 隐藏左右分隔拖拽手柄；
+     - 隐藏 `ContextMenu`、`AddFilePopup`、`FileSelectorPopup`。
+   - `components/AppSidebar.vue`
+     - 隐藏“Add”“Import”；保留“Refresh”；
+     - 阻断右键菜单触发。
+     - 移动端下侧栏占满宽度（配合全局 CSS column 布局）。
+   - `components/MiddlePanel.vue`
+     - 隐藏“Add JSON file”按钮；
+     - 禁用重命名（双击/F2）与右键菜单；
+     - 仍可点击选择文件查看。
+   - `components/RightPanel.vue`
+     - 隐藏编辑按钮与编辑器、Schema 编辑器；
+     - 隐藏 Diff 视图；
+     - 保留“复制到剪贴板”按钮；
+     - 按状态显示“Schema 定义”或“JSON 内容”查看器。
+
+3. 布局与样式
+   - `src/style.css` 已有 `<768px` 下将 `.app-container` 切至纵向堆叠的规则；
+   - 补充移动端 `body` 允许滚动；
+   - 侧栏移动端宽度 100%，中间面板 100%，右侧面板自适应高度。
+
+## 关键改动（文件）
+- `src/stores/ui.ts`
+  - 新增：`isMobile: Ref<boolean>` 与 `initializeResponsive()`；
+  - 导出 `isMobile` 与初始化函数。
+- `src/App.vue`
+  - `onMounted` 时调用 `ui.initializeResponsive()`。
+- `src/views/Home.vue`
+  - 基于 `ui.isMobile` 隐藏拖拽手柄、`ContextMenu`、弹窗组件。
+- `src/components/AppSidebar.vue`
+  - 基于 `ui.isMobile` 隐藏新增/导入按钮；阻断右键；移动端宽度样式。
+- `src/components/MiddlePanel.vue`
+  - 基于 `ui.isMobile` 隐藏“Add”按钮；禁用右键与重命名。
+- `src/components/RightPanel.vue`
+  - 基于 `ui.isMobile` 隐藏编辑器、编辑按钮与 Diff 组件；保留复制。
+- `src/style.css`
+  - 移动端下 `body` 允许滚动；其余移动栈式布局规则沿用既有实现。
+
+## 行为验证（手动）
+1. 窗口宽度 < 768px：
+   - 仅显示三段式纵向堆叠：侧栏（Schema 列表）→ 中间列表（文件）→ 右侧（查看器）。
+   - 看不到编辑、新增、导入、Diff、右键菜单与拖拽手柄。
+   - 点击 Schema → 展示其关联文件；点击文件 → 右侧显示 JSON 内容；右上可复制。
+2. 窗口宽度 ≥ 768px：
+   - 保持桌面端完整功能。
+
+## 兼容性
+- 不改变路由与存储结构；
+- 桌面端/宽屏行为不变；
+- Web 模式下“保存到内存”的既有逻辑保持不变，仅在移动端被隐藏 UI 入口。
+
+## 相关文件列表
+- `src/stores/ui.ts`
+- `src/App.vue`
+- `src/views/Home.vue`
+- `src/components/AppSidebar.vue`
+- `src/components/MiddlePanel.vue`
+- `src/components/RightPanel.vue`
+- `src/style.css`
+
+## 备注
+- 本次未新增构建产物与依赖；`.gitignore` 现有配置已覆盖常见目录与缓存。

--- a/src/App.vue
+++ b/src/App.vue
@@ -7,6 +7,16 @@
 
 <script setup lang="ts">
 import StatusBar from '@/components/StatusBar.vue'
+import { onMounted } from 'vue'
+import { useUIStore } from '@/stores/ui'
+
+const ui = useUIStore()
+
+onMounted(() => {
+  try {
+    ui.initializeResponsive()
+  } catch {}
+})
 </script>
 
 <style scoped>

--- a/src/components/AppSidebar.vue
+++ b/src/components/AppSidebar.vue
@@ -11,8 +11,8 @@
         </div>
         <ThemeToggle />
         <div class="schema-actions">
-          <button class="apple-btn tinted small" @click="handleAddSchema">Add</button>
-          <button class="apple-btn bordered small" @click="handleImportSchema">Import</button>
+          <button class="apple-btn tinted small" @click="handleAddSchema" v-if="!ui.isMobile">Add</button>
+          <button class="apple-btn bordered small" @click="handleImportSchema" v-if="!ui.isMobile">Import</button>
           <button class="apple-btn bordered small" @click="handleRefresh">Refresh</button>
         </div>
       </div>
@@ -24,7 +24,7 @@
         class="apple-list-item schema"
         :class="{ selected: appStore.currentSchema?.path === schema.path }"
         @click="selectSchema(schema)"
-        @contextmenu.prevent="showContextMenu($event, schema)"
+        @contextmenu.prevent="ui.isMobile ? undefined : showContextMenu($event, schema)"
       >
         <div class="schema-content">
           <span class="schema-icon">📄</span>
@@ -61,6 +61,9 @@ const router = useRouter()
 const runtime = getPlatformRuntime()
 
 const leftPanelStyle = computed(() => {
+  if (ui.isMobile) {
+    return { width: '100%', minWidth: 'unset', maxWidth: 'unset' }
+  }
   if (ui.leftSidebarCollapsed) {
     return { width: '48px', minWidth: '48px' }
   }

--- a/src/components/MiddlePanel.vue
+++ b/src/components/MiddlePanel.vue
@@ -4,7 +4,7 @@
       <div class="header-top">
         <div class="middle-panel-title">Associated JSON Files</div>
         <button 
-          v-if="appStore.currentSchema" 
+          v-if="appStore.currentSchema && !ui.isMobile" 
           class="apple-btn tinted small"
           @click="openAddFilePopup"
           title="Add JSON file"
@@ -32,8 +32,8 @@
         }"
         :data-file-path="file.path"
         @click="selectFile(file)"
-        @contextmenu.prevent="showContextMenu($event, file)"
-        @dblclick="startInlineRename(file)"
+        @contextmenu.prevent="ui.isMobile ? undefined : showContextMenu($event, file)"
+        @dblclick="ui.isMobile ? undefined : startInlineRename(file)"
       >
         <!-- Normal display mode -->
         <div v-if="!inlineRename.isEditing(file)" class="json-file-name" :title="`${file.name}\n\nDouble-click or press F2 to rename`">
@@ -175,6 +175,9 @@ function handleRenameEvent(event: CustomEvent) {
 
 // Handle F2 key for rename
 function handleKeyDown(event: KeyboardEvent) {
+  if (ui.isMobile) {
+    return
+  }
   if (event.key === 'F2' && appStore.currentJsonFile && !inlineRename.editingFile.value) {
     event.preventDefault()
     startInlineRename(appStore.currentJsonFile)

--- a/src/components/RightPanel.vue
+++ b/src/components/RightPanel.vue
@@ -36,7 +36,7 @@
             {{ appStore.currentJsonFile.isValid ? 'Valid JSON' : `${appStore.currentJsonFile.errors.length} validation errors` }}
           </span>
         </div>
-        <div class="panel-actions" v-if="ui.isEditingSchema && appStore.currentSchema">
+        <div class="panel-actions" v-if="ui.isEditingSchema && appStore.currentSchema && !ui.isMobile">
           <button class="apple-btn filled small icon-only" @click="saveSchemaChanges" title="Save Schema">
             <SaveIcon />
           </button>
@@ -53,13 +53,13 @@
           <button class="apple-btn tinted small icon-only" @click="copyToClipboard" title="Copy JSON">
             <CopyIcon />
           </button>
-          <button class="apple-btn bordered small icon-only" @click="toggleEditMode" title="Edit JSON" v-if="!ui.isEditMode">
+          <button class="apple-btn bordered small icon-only" @click="toggleEditMode" title="Edit JSON" v-if="!ui.isEditMode && !ui.isMobile">
             <EditIcon />
           </button>
-          <button class="apple-btn filled small icon-only" @click="saveChanges" title="Save Changes" v-if="ui.isEditMode">
+          <button class="apple-btn filled small icon-only" @click="saveChanges" title="Save Changes" v-if="ui.isEditMode && !ui.isMobile">
             <SaveIcon />
           </button>
-          <button class="apple-btn plain small icon-only" @click="cancelEdit" title="Cancel Edit" v-if="ui.isEditMode">
+          <button class="apple-btn plain small icon-only" @click="cancelEdit" title="Cancel Edit" v-if="ui.isEditMode && !ui.isMobile">
             <CancelIcon />
           </button>
         </div>
@@ -67,11 +67,11 @@
     </div>
     <div class="json-content">
       <!-- Diff Viewer -->
-      <JsonDiffViewer v-if="ui.isDiffMode" />
+      <JsonDiffViewer v-if="ui.isDiffMode && !ui.isMobile" />
 
       <!-- Schema Editor -->
       <AdvancedJsonEditor
-        v-else-if="ui.isEditingSchema && appStore.currentSchema"
+        v-else-if="ui.isEditingSchema && appStore.currentSchema && !ui.isMobile"
         v-model="editSchemaContent"
         placeholder="Enter schema JSON..."
         @validation-change="handleSchemaValidationChange"
@@ -114,7 +114,7 @@
 
       <!-- JSON Editor -->
       <AdvancedJsonEditor
-        v-else-if="appStore.currentJsonFile && ui.isEditMode"
+        v-else-if="appStore.currentJsonFile && ui.isEditMode && !ui.isMobile"
         v-model="editContent"
         :schema="appStore.currentSchema?.content"
         placeholder="Enter JSON content..."

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -11,6 +11,9 @@ export const useUIStore = defineStore('ui', () => {
   const isEditingSchema = ref(false)
   const isDiffMode = ref(false)
 
+  // Responsive
+  const isMobile = ref(false)
+
   // Layout - sidebar
   const leftSidebarWidth = ref<number>(300)
   const leftSidebarCollapsed = ref<boolean>(false)
@@ -175,6 +178,17 @@ export const useUIStore = defineStore('ui', () => {
     }
   }
 
+  // Responsive initialization
+  function initializeResponsive() {
+    const update = () => {
+      try {
+        isMobile.value = window.innerWidth <= 767
+      } catch {}
+    }
+    update()
+    window.addEventListener('resize', update)
+  }
+
   // Watch for theme changes
   watch(currentTheme, () => {
     applyTheme()
@@ -201,6 +215,7 @@ export const useUIStore = defineStore('ui', () => {
     isViewingSchema,
     isEditingSchema,
     isDiffMode,
+    isMobile,
     leftSidebarWidth,
     leftSidebarCollapsed,
     statusMessage,
@@ -222,6 +237,7 @@ export const useUIStore = defineStore('ui', () => {
     initializeTheme,
     initializeLayout,
     initializeKeyboardShortcuts,
+    initializeResponsive,
   }
 })
 

--- a/src/style.css
+++ b/src/style.css
@@ -262,6 +262,13 @@ body {
   transition: var(--apple-transition);
 }
 
+/* Mobile: disable text selection blocking interactions if needed */
+@media (max-width: 767px) {
+  body {
+    overflow: auto;
+  }
+}
+
 /* Apple HIG Typography Scale */
 .text-xs { font-size: var(--text-xs); line-height: var(--leading-normal); }
 .text-sm { font-size: var(--text-sm); line-height: var(--leading-normal); }

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -4,25 +4,31 @@
     <AppSidebar />
     
     <!-- Resize Handle -->
-    <div class="resize-handle" id="leftResize" @mousedown="startLeftResize" @dblclick="toggleLeftCollapse"></div>
+    <div 
+      v-if="!ui.isMobile" 
+      class="resize-handle" 
+      id="leftResize" 
+      @mousedown="startLeftResize" 
+      @dblclick="toggleLeftCollapse"
+    ></div>
     
     <!-- Middle Panel - JSON Files List -->
     <MiddlePanel />
     
     <!-- Resize Handle -->
-    <div class="resize-handle" id="middleResize"></div>
+    <div v-if="!ui.isMobile" class="resize-handle" id="middleResize"></div>
     
     <!-- Right Panel - JSON Content View -->
     <RightPanel />
     
-    <!-- Context Menu -->
-    <ContextMenu />
+    <!-- Context Menu (disabled on mobile view-only) -->
+    <ContextMenu v-if="!ui.isMobile" />
     
-    <!-- Add File Popup -->
-    <AddFilePopup />
+    <!-- Add File Popup (disabled on mobile view-only) -->
+    <AddFilePopup v-if="!ui.isMobile" />
     
-    <!-- File Selector Popup for Diff -->
-    <FileSelectorPopup />
+    <!-- File Selector Popup for Diff (disabled on mobile view-only) -->
+    <FileSelectorPopup v-if="!ui.isMobile" />
   </div>
 </template>
 


### PR DESCRIPTION
Implement a view-only mode for mobile and small screens to optimize display and disable editing features.

Previously, the UI components on mobile stacked poorly, and editing functionality was not intended for this form factor. This PR introduces a responsive mode that simplifies the layout and restricts interactions to viewing schemas and JSON files.

---
Linear Issue: [LC-92](https://linear.app/manyjson/issue/LC-92/优化手机端移动端小屏幕展示效果)

<a href="https://cursor.com/background-agent?bcId=bc-ae7565b5-43bc-46f9-9e27-df1ca75502e2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ae7565b5-43bc-46f9-9e27-df1ca75502e2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

